### PR TITLE
add args for linux tests

### DIFF
--- a/src/main/groovy/com/jetbrains/node/envs/NodeEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/node/envs/NodeEnvsPlugin.groovy
@@ -95,7 +95,7 @@ class NodeEnvsPlugin implements Plugin<Project> {
                     executable new File(env.dir, "bin/npm").absolutePath
                     break
             }
-            args = ["install", "-g", *packages]
+            args = ["install", "-g", "--allow-root", "--unsafe-perm=true", *packages]
         })
     }
 


### PR DESCRIPTION
On mac/linux we can't install the following packages without this args:
1. angular/cli
2. vue/cli